### PR TITLE
Add GitHub Skills activity to activities list

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program.",
+        "schedule": "Thursdays, 4:00 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
This pull request adds the "GitHub Skills" activity to the list of available extracurricular activities, as announced by the principal. Students can now register for this new activity, which is part of the GitHub Certifications program and will help with college applications.

- Added activity details (description, schedule, max participants)
- Activity is available for registration like the others

Closes #6.